### PR TITLE
reverse geocode search implemented

### DIFF
--- a/cmd/mapbox-revgeocode/main.go
+++ b/cmd/mapbox-revgeocode/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/odeke-em/mapbox"
+)
+
+func main() {
+	var lat, lon float64
+	flag.Float64Var(&lat, "lat", 38.8971, "latitude")
+	flag.Float64Var(&lon, "lon", -77.0366, "longitude")
+	flag.Parse()
+
+	client, err := mapbox.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	revReq := &mapbox.ReverseGeocodeRequest{
+		Query: fmt.Sprintf("%f,%f", lon, lat),
+	}
+
+	resp, err := client.ReverseGeocoding(revReq)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("#%v\n", resp)
+	for i, feature := range resp.Features {
+		fmt.Printf("Feature: #%d: %#v\n", i, feature)
+	}
+}

--- a/mapbox.go
+++ b/mapbox.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"sync"
 )
 
@@ -24,11 +25,16 @@ func (c *Client) SetAPIKey(key string) {
 	c.apiKey = key
 }
 
+var defaultEnvAPIKey = os.Getenv("MAPBOX_API_KEY")
+
 func (c *Client) APIKey() string {
 	c.RLock()
 	defer c.RUnlock()
 
-	return c.apiKey
+	if c.apiKey != "" {
+		return c.apiKey
+	}
+	return defaultEnvAPIKey
 }
 
 type LatLonPair []float32
@@ -97,9 +103,11 @@ func (c *Client) APIVersion() string {
 	}
 }
 
+var baseURL = "https://api.mapbox.com"
+
 func (c *Client) durationsURL() string {
-	return fmt.Sprintf("https://api.mapbox.com/distances/%s/mapbox/driving?access_token=%s",
-		c.APIVersion(), c.APIKey())
+	return fmt.Sprintf("%s/distances/%s/mapbox/driving?access_token=%s",
+		baseURL, c.APIVersion(), c.APIKey())
 }
 
 func (c *Client) _httpClient() *http.Client {

--- a/places.go
+++ b/places.go
@@ -1,0 +1,173 @@
+package mapbox
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+)
+
+type GeocodeMode string
+
+const (
+	GeocodePlaces          GeocodeMode = "mapbox.places"
+	GeocodePermanentPlaces GeocodeMode = "mapbox.places-permanent"
+)
+
+func (gm GeocodeMode) String() string {
+	if gm == "" {
+		gm = GeocodePlaces
+	}
+	return string(gm)
+}
+
+// ReverseGeocoding Converts coordinates to place names
+// -77.036,38.897 -> 1600 Pennsylvania Ave NW.
+// Request format:
+// GET /geocoding/v5/{mode}/{query}.json
+func (c *Client) ReverseGeocoding(req *ReverseGeocodeRequest) (*GeocodeResponse, error) {
+	asURLValues, err := toURLValues(req.Request)
+	if err != nil {
+		return nil, err
+	}
+
+	asURLValues.Add("access_token", c.APIKey())
+
+	// GET /geocoding/v5/{mode}/{query}.json
+	outURL := fmt.Sprintf("%s/geocoding/v5/%s/%s.json?%s",
+		baseURL, req.Mode, req.Query, asURLValues.Encode())
+
+	httpClient := c._httpClient()
+	res, err := httpClient.Get(outURL)
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+	if !statusOK(res.StatusCode) {
+		return nil, fmt.Errorf("%s", res.Status)
+	}
+
+	blob, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	gres := new(GeocodeResponse)
+	if err := json.Unmarshal(blob, gres); err != nil {
+		return nil, err
+	}
+	return gres, nil
+}
+
+func toURLValues(v interface{}) (url.Values, error) {
+	// First JSON serialize it
+	blob, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+
+	recv := make(map[string]interface{})
+	if err := json.Unmarshal(blob, &recv); err != nil {
+		return nil, err
+	}
+
+	outValues := make(url.Values)
+	for key, ival := range recv {
+		if ival == nil {
+			continue
+		}
+		switch typ := ival.(type) {
+		case string:
+			outValues.Add(key, typ)
+		case uint:
+			outValues.Add(key, fmt.Sprintf("%d", typ))
+		case bool:
+			outValues.Add(key, fmt.Sprintf("%v", typ))
+		case []float32:
+			for _, fV := range typ {
+				outValues.Add(key, fmt.Sprintf("%f", fV))
+			}
+		case []string:
+			for _, strV := range typ {
+				outValues.Add(key, strV)
+			}
+		case *LatLonPair:
+			for _, fV := range *typ {
+				outValues.Add(key, fmt.Sprintf("%sf", fV))
+			}
+			outValues.Add(key, fmt.Sprintf("%v", typ))
+		default:
+		}
+	}
+
+	return outValues, nil
+}
+
+type ReverseGeocodeRequest struct {
+	Query   string      `json:"query"`
+	Mode    GeocodeMode `json:"mode"`
+	Request *GeocodeRequest
+}
+
+type GeocodeType string
+
+const (
+	GTypeRegion       GeocodeType = "region"
+	GTypePostcode     GeocodeType = "postcode"
+	GTypePlace        GeocodeType = "place"
+	GTypeLocality     GeocodeType = "locality"
+	GTypeNeighborhood GeocodeType = "neighborhood"
+	GTypeAddress      GeocodeType = "address"
+	GTypePOI          GeocodeType = "poi"
+	GTypePOILandmark  GeocodeType = "poi.landmark"
+)
+
+type GeocodeRequest struct {
+	// Country is a set of one or more countries
+	// specified with ISO 3166 alpha 2 country codes.
+	Country []string `json:"country,omitempty"`
+
+	Limit uint          `json:"limit,omitempty"`
+	Types []GeocodeType `json:"types,omitempty"`
+
+	Proximity    *LatLonPair `json:"proximity,omitempty"`
+	BoundingBox  []float32   `json:"bbox,omitempty"`
+	AutoComplete bool        `json:"autocomplete,omitempty"`
+}
+
+type Geometry struct {
+	Type        string    `json:"type"`
+	Coordinates []float32 `json:"coordinates"`
+}
+
+type GeocodeContext struct {
+	Id        string `json:"id"`
+	Text      string `json:"text"`
+	ShortCode string `json:"short_code"`
+	Wikidata  string `json:"wikidata"`
+}
+
+type GeocodeFeature struct {
+	Id        string  `json:"id"`
+	Type      string  `json:"type"`
+	Text      string  `json:"text"`
+	PlaceName string  `json:"place_name"`
+	Relevance float32 `json:"relevance"`
+
+	Properties *GeocodeProperty  `json:"properties"`
+	Context    []*GeocodeContext `json:"context"`
+
+	BoundingBox []float32 `json:"bbox"`
+	Center      []float32 `json:"center"`
+	Geometry    *Geometry `json:"geometry"`
+	Attribution string    `json:"attribution"`
+}
+
+type GeocodeProperty map[string]interface{}
+
+type GeocodeResponse struct {
+	Type     string            `json:"type,omitempty"`
+	Query    *LatLonPair       `json:"query,omitempty"`
+	Features []*GeocodeFeature `json:"features,omitempty"`
+}


### PR DESCRIPTION
Fixes #1.

Implemented reverse geocode search so that folks
can search by latitude and longitude.
A sample CLI app is present in cmd/mapbox-revgeocode/main.go
that takes args:
```shell
$ go run main.go --lat 53.522668 --lon -113.624169
```

to search for location at West Edmonton Mall as well as the features
close by.

Note:
* Make sure to set in your environment key `MAPBOX_API_KEY`.