### PR TITLE
reverse-geocode: simplify with helper LookupLatLon

### DIFF
--- a/cmd/mapbox-revgeocode/main.go
+++ b/cmd/mapbox-revgeocode/main.go
@@ -19,11 +19,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	revReq := &mapbox.ReverseGeocodeRequest{
-		Query: fmt.Sprintf("%f,%f", lon, lat),
-	}
-
-	resp, err := client.ReverseGeocoding(revReq)
+	resp, err := client.LookupLatLon(lat, lon)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/places.go
+++ b/places.go
@@ -21,6 +21,14 @@ func (gm GeocodeMode) String() string {
 	return string(gm)
 }
 
+// LookupLatLon is a helper to reverse geocoding
+// lookup a latitude and longitude pair.
+func (c *Client) LookupLatLon(lat, lon float64) (*GeocodeResponse, error) {
+	return c.ReverseGeocoding(&ReverseGeocodeRequest{
+		Query: fmt.Sprintf("%f,%f", lon, lat),
+	})
+}
+
 // ReverseGeocoding Converts coordinates to place names
 // -77.036,38.897 -> 1600 Pennsylvania Ave NW.
 // Request format:


### PR DESCRIPTION
In usages I've found myself having to make a raw query ie
```go
&mapbox.ReverseGeocodeRequest{Query: fmt.Sprintf("%v,%v", lat, lon)}
```

This is a very awkard usage and in fact the users of the API
shouldn't have to worry about which comes first: lat or lon.

This change simplifies it by introducing a helper method
LookupLatLon which takes in (lat, lon) and performs a reverse
geocode lookup as was with the original ReverseGeocoding request.
It also simplifies the example usage.