### PR TITLE
places: LookupPlace method implemented

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,49 @@
+package mapbox_test
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/odeke-em/mapbox"
+)
+
+func Example_client_LookupPlace() {
+	client, err := mapbox.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Time for some tacos, let's lookup that new spot.
+	match, err := client.LookupPlace("Tacquerias El Farolito")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for i, feat := range match.Features {
+		fmt.Printf("Match: #%d Name: %q Relevance: %v Center: %#v\n", i, feat.PlaceName, feat.Relevance, feat.Center)
+		for j, ctx := range feat.Context {
+			fmt.Printf("\tContext: #%d:: %#v\n", j, ctx)
+		}
+		fmt.Printf("\n\n")
+	}
+}
+
+func Example_client_LookupLatLon() {
+	client, err := mapbox.NewClient()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	resp, err := client.LookupLatLon(38.8971, -77.0366)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for i, feat := range resp.Features {
+		fmt.Printf("Match: #%d Name: %q Relevance: %v Center: %#v\n", i, feat.PlaceName, feat.Relevance, feat.Center)
+		for j, ctx := range feat.Context {
+			fmt.Printf("\tContext: #%d:: %#v\n", j, ctx)
+		}
+		fmt.Printf("\n\n")
+	}
+}

--- a/mapbox.go
+++ b/mapbox.go
@@ -133,7 +133,10 @@ func (c *Client) RequestDuration(dreq *DurationRequest) (*DurationResponse, erro
 	if err != nil {
 		return nil, err
 	}
-	defer res.Body.Close()
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+
 	if !statusOK(res.StatusCode) {
 		return nil, fmt.Errorf("%s", res.Status)
 	}

--- a/places.go
+++ b/places.go
@@ -21,6 +21,14 @@ func (gm GeocodeMode) String() string {
 	return string(gm)
 }
 
+// LookupPlace looks up the coordinates and information of a place
+// for example "Los Angeles" or "Edmonton".
+func (c *Client) LookupPlace(query string) (*GeocodeResponse, error) {
+	return c.doGeoCodingRequest(&ReverseGeocodeRequest{
+		Query: query,
+	})
+}
+
 // LookupLatLon is a helper to reverse geocoding
 // lookup a latitude and longitude pair.
 func (c *Client) LookupLatLon(lat, lon float64) (*GeocodeResponse, error) {
@@ -31,9 +39,13 @@ func (c *Client) LookupLatLon(lat, lon float64) (*GeocodeResponse, error) {
 
 // ReverseGeocoding Converts coordinates to place names
 // -77.036,38.897 -> 1600 Pennsylvania Ave NW.
+func (c *Client) ReverseGeocoding(req *ReverseGeocodeRequest) (*GeocodeResponse, error) {
+	return c.doGeoCodingRequest(req)
+}
+
 // Request format:
 // GET /geocoding/v5/{mode}/{query}.json
-func (c *Client) ReverseGeocoding(req *ReverseGeocodeRequest) (*GeocodeResponse, error) {
+func (c *Client) doGeoCodingRequest(req *ReverseGeocodeRequest) (*GeocodeResponse, error) {
 	asURLValues, err := toURLValues(req.Request)
 	if err != nil {
 		return nil, err

--- a/testdata/places-LA.json
+++ b/testdata/places-LA.json
@@ -1,0 +1,94 @@
+{
+  "type": "FeatureCollection",
+  "query": [
+    "los",
+    "angeles"
+  ],
+  "features": [
+    {
+      "id": "place.33004",
+      "type": "Feature",
+      "text": "Los Angeles",
+      "place_name": "Los Angeles, California, United States",
+      "relevance": 0.99,
+      "properties": {
+        "wikidata": "Q65"
+      },
+      "bbox": [
+        -118.521455009776,
+        33.90189299,
+        -118.12130699003,
+        34.1614390095055
+      ],
+      "center": [
+        -118.2439,
+        34.0544
+      ],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -118.2439,
+          34.0544
+        ]
+      },
+      "context": [
+        {
+          "id": "postcode.8055854450707500",
+          "text": "90012"
+        },
+        {
+          "id": "region.6020809690311220",
+          "text": "California",
+          "short_code": "US-CA",
+          "wikidata": "Q99"
+        },
+        {
+          "id": "country.12862386939497690",
+          "text": "United States",
+          "short_code": "us",
+          "wikidata": "Q30"
+        }
+      ]
+    },
+    {
+      "id": "place.15100",
+      "type": "Feature",
+      "text": "Los Ángeles",
+      "place_name": "Los Ángeles, Bío Bío, Chile",
+      "relevance": 0.99,
+      "properties": {},
+      "bbox": [
+        -72.6835636,
+        -37.6587686,
+        -72.0420575,
+        -37.1736364
+      ],
+      "center": [
+        -72.3277,
+        -37.4079
+      ],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -72.3277,
+          -37.4079
+        ]
+      },
+      "context": [
+        {
+          "id": "region.7807420235045040",
+          "text": "Bío Bío",
+          "short_code": "CL-BI",
+          "wikidata": "Q2170"
+        },
+        {
+          "id": "country.14661701841731110",
+          "text": "Chile",
+          "short_code": "cl",
+          "wikidata": "Q298"
+        }
+      ]
+    }
+  ],
+  "attribution": "NOTICE: © 2016 Mapbox and its suppliers. All rights reserved. Use of this data is subject to the Mapbox Terms of Service (https://www.mapbox.com/about/maps/). This response and the information it contains may not be retained."
+}


### PR DESCRIPTION
LookupPlace method implemented to allow for folks to lookup
a place by its symbolic name e.g
* To look up "Tacqueria El Farolito" in San Francisco
```go
package main

import (
  "fmt"
  "log"

  "github.com/odeke-em/mapbox"
)

func main() {
  client, err := mapbox.NewClient()
  if err != nil {
    log.Fatal(err)
  }

  // Time for some tacos, let's lookup that new spot.
  match, err := client.LookupPlace("Tacquerias El Farolito")
  if err != nil {
    log.Fatal(err)
  }

  for i, feat := range match.Features {
    fmt.Printf("Match: #%d Name: %q Relevance: %v Center: %#v\n", i,
feat.PlaceName, feat.Relevance, feat.Center)
    for j, ctx := range feat.Context {
      fmt.Printf("\tContext: #%d:: %#v\n", j, ctx)
    }
    fmt.Printf("\n\n")
  }
}
```

* Updated the tests to multiplex on different routes and also read
expected data from disk ie "./testdata/"
* Added an examples_test.go file to show copy and pastable examples +
have runnable tests invoking the methods so code doesn't go stale.